### PR TITLE
Netlify: Fix redirect ordering

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,8 +15,12 @@
 
 # Redirect legacy URLs to their equivalents
 [[redirects]]
-  from    = "/assets/resume/resume.:extension"
-  to      = "/resume.:extension"
+  from    = "/assets/resume/resume.txt"
+  to      = "/resume.txt"
+
+[[redirects]]
+  from    = "/assets/resume/resume.pdf"
+  to      = "/resume.pdf"
 
 [[redirects]]
   from    = "/contact_me/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,29 +12,29 @@
 [context.branch-deploy]
   command = "REACT_APP_STAGE=dev npm run build"
 
-[[redirects]]
-  from    = "/*"
-  to      = "/index.html"
-  status  = 200
 
+# Redirect legacy URLs to their equivalents
 [[redirects]]
-  from    = "/assets/resume/resume.*"
-  to      = "/resume.:splat"
-  status  = 301
+  from    = "/assets/resume/resume.:extension"
+  to      = "/resume.:extension"
 
 [[redirects]]
   from    = "/contact_me/"
   to      = "/"
-  status  = 301
 
 [[redirects]]
   from    = "/projects/"
   to      = "/"
-  status  = 301
+
+# Server the SPA
+[[redirects]]
+  from    = "/*"
+  to      = "/index.html"
+  status  = 200
 
 # The HTML version is the canonical version of the Resume. Alternate assets
 # can indicate this to crawlers via the link header.
 [[headers]]
   for = "/resume.*"
   [headers.values]
-    Link = '/resume; rel="canonical";'
+    Link = '/resume/; rel="canonical";'


### PR DESCRIPTION
We want our old url redirects to fire before our SPA redirect, so we need to put those rules first.

This also removes unnecessary status = 301 specifiers. That is the default behavior.