### PR TITLE
Trailing slash links

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import makeStore from './store';
 import { NoticeManager } from 'notices';
 import ScrollManager from 'router/components/ScrollManager';
 import AnimatedSwitch from 'router/components/AnimatedSwitch';
+import TrailingSlashRedirect from 'router/components/TrailingSlashRedirect';
 import Home from 'views/Home';
 import Resume from 'resume/views/Resume';
 import FourOhFour from 'views/FourOhFour';
@@ -23,6 +24,12 @@ function App() {
         <Router>
           <ScrollManager>
             <AnimatedSwitch>
+              <Route
+                exact
+                strict
+                path="/:url*"
+                component={TrailingSlashRedirect}
+              />
               <Route path="/" exact component={Home} />
               <Route path="/resume/" exact component={Resume} />
               <Route component={FourOhFour} />

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ function App() {
           <ScrollManager>
             <AnimatedSwitch>
               <Route path="/" exact component={Home} />
-              <Route path="/resume" exact component={Resume} />
+              <Route path="/resume/" exact component={Resume} />
               <Route component={FourOhFour} />
             </AnimatedSwitch>
           </ScrollManager>

--- a/src/router/components/TrailingSlashRedirect.js
+++ b/src/router/components/TrailingSlashRedirect.js
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react';
+import { Redirect } from 'react-router';
+
+type Props = {
+  location: {
+    pathname: string
+  }
+};
+
+export default function TrailingSlashRedirect(props: Props) {
+  const { location } = props;
+
+  console.warn('Missing trailing slash in route; adding slash via redirect.');
+
+  return <Redirect to={`${location.pathname}/`} />;
+}

--- a/src/views/Home.js
+++ b/src/views/Home.js
@@ -34,7 +34,7 @@ export default function Home() {
         </p>
         <Columns className={styles.cta_columns}>
           <div>
-            <LinkButton to="/resume" className={styles.primary_cta}>
+            <LinkButton to="/resume/" className={styles.primary_cta}>
               Resume
             </LinkButton>
           </div>


### PR DESCRIPTION
Our slashes paths don't seem to play nicely with Netlify's URL beautification behaviors:

Accessing /resume resolves to a 301 to /resume/
Navigating to /resume within the app takes the browser to /resume

 Adding slashes should resolve that conflict:

/resume will 301 to /resume/
Navigating to /resume/ in app will take the browser to /resume/

Additionally, this adds client-side logic to enforce trailing slashes to ensure that even links that aren't fixed here also take the user to a path with a trailing slash.