### PR TITLE
Wire up ContactForm to submit to Netlify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5508,6 +5508,11 @@
         }
       }
     },
+    "extendable-error": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.5.tgz",
+      "integrity": "sha1-EiMIpwl7yJomOyxPvwiceBQOO20="
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@fortawesome/react-fontawesome": "^0.1.5",
     "aos": "^3.0.0-beta.6",
     "classnames": "^2.2.6",
+    "extendable-error": "^0.1.5",
     "react": "^16.10.1",
     "react-dom": "^16.10.1",
     "react-helmet-async": "^1.0.3",

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -1,7 +1,5 @@
 // @flow
-function wait() {
-  return new Promise(r => setTimeout(r, 1000));
-}
+import { ExtendableError } from 'extendable-error';
 
 export type EmailNotice = {|
   name: string,
@@ -9,7 +7,57 @@ export type EmailNotice = {|
   message: string
 |};
 
+type APIErrorArgs = {
+  message?: string,
+  response: Response,
+  data: {},
+  code: number
+};
+
+export class APIError extends ExtendableError {
+  constructor({
+    message = 'API error',
+    response,
+    data,
+    code
+  }: APIErrorArgs = {}) {
+    super(message);
+    this.response = response;
+    this.data = data;
+    this.code = code;
+  }
+}
+
+export default async function parseResponse(response: Response) {
+  const { status } = response;
+
+  console.info(`API Response ${status} ${response.url}`);
+
+  // HTTP 204 No content. (Nothing to deserialize).
+  if (status === 204) return;
+
+  const data = await response.json().catch(() => ({}));
+  const errorData = { data, code: status };
+
+  if (status >= 400)
+    throw new APIError({ response, data: errorData, code: status });
+
+  return data;
+}
+
 export async function sendEmailNotice(notice: EmailNotice) {
-  await wait();
-  throw Error('Not Implemented.');
+  const body = new URLSearchParams({
+    'form-name': 'contact',
+    ...notice
+  }).toString();
+
+  const response = await fetch('/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    body
+  });
+
+  return parseResponse(response);
 }

--- a/src/contact/actions.js
+++ b/src/contact/actions.js
@@ -8,6 +8,7 @@ import { setExpiringNotice } from 'notices';
 export function sendMessage(message: EmailNotice) {
   async function sendMessageAsync(dispatch: Dispatch) {
     await sendEmailNotice(message);
+
     dispatch(setExpiringNotice('Your message is on its way!'));
   }
 

--- a/src/contact/components/ContactForm.js
+++ b/src/contact/components/ContactForm.js
@@ -47,7 +47,12 @@ export default function ContactForm() {
   };
 
   return (
-    <form className={styles.container} onSubmit={handleSubmit}>
+    <form
+      className={styles.container}
+      onSubmit={handleSubmit}
+      name="contact"
+      data-netlify="true"
+    >
       <ContactErrorMessage />
       <label htmlFor="name">Name</label>
       <Input


### PR DESCRIPTION
The `data-netlify="true"` attribute on the ContactForm flags it for submission handling by Netlify's build process.

The api-client stub is expanded to serialize the form data and submit it in a way that is appropriate for netlify interception (it includes an appropriate form-name parameter).