### PR TITLE
Netlify: enable production builds in all environments

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,16 +1,16 @@
 [build]
   base    = ""
   publish = "build"
-  command = "REACT_APP_STAGE=dev npm run build"
+  command = "REACT_APP_STAGE=prod npm run build"
 
 [context.production]
   command = "REACT_APP_STAGE=prod npm run build"
 
 [context.deploy-preview]
-  command = "REACT_APP_STAGE=dev npm run build"
+  command = "REACT_APP_STAGE=prod npm run build"
 
 [context.branch-deploy]
-  command = "REACT_APP_STAGE=dev npm run build"
+  command = "REACT_APP_STAGE=prod npm run build"
 
 
 # Redirect legacy URLs to their equivalents


### PR DESCRIPTION
Ideally we should be QAing releases using the same builds production will use. We don't have much internal logic wired to the env, so this should be fine for now.