### PR TITLE
ScrollManager: don't accept children

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,19 +22,18 @@ function App() {
     <Provider store={store}>
       <HelmetProvider>
         <Router>
-          <ScrollManager>
-            <AnimatedSwitch>
-              <Route
-                exact
-                strict
-                path="/:url*"
-                component={TrailingSlashRedirect}
-              />
-              <Route path="/" exact component={Home} />
-              <Route path="/resume/" exact component={Resume} />
-              <Route component={FourOhFour} />
-            </AnimatedSwitch>
-          </ScrollManager>
+          <AnimatedSwitch>
+            <Route
+              exact
+              strict
+              path="/:url*"
+              component={TrailingSlashRedirect}
+            />
+            <Route path="/" exact component={Home} />
+            <Route path="/resume/" exact component={Resume} />
+            <Route component={FourOhFour} />
+          </AnimatedSwitch>
+          <ScrollManager />
         </Router>
         <NoticeManager />
       </HelmetProvider>

--- a/src/router/components/ScrollManager.js
+++ b/src/router/components/ScrollManager.js
@@ -1,13 +1,23 @@
 // @flow
-import React from 'react';
+import { useEffect } from 'react';
 import { withRouter } from 'react-router';
 
 type Props = {
   location: { pathname: string }
 };
 
+let MOUNTED = false;
+
 function ScrollManager({ location: { pathname } }: Props) {
-  React.useEffect(() => {
+  useEffect(() => {
+    // Disregard the first pathname change. That's the initial url and
+    // we want to honor whatever #hash is specified by not scrolling up to the
+    // top.
+    if (!MOUNTED) {
+      MOUNTED = true;
+      return;
+    }
+
     window.scrollTo(0, 0);
   }, [pathname]);
 

--- a/src/router/components/ScrollManager.js
+++ b/src/router/components/ScrollManager.js
@@ -1,18 +1,17 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import { withRouter } from 'react-router';
 
 type Props = {
-  children: React.Node,
   location: { pathname: string }
 };
 
-function ScrollManager({ children, location: { pathname } }: Props) {
+function ScrollManager({ location: { pathname } }: Props) {
   React.useEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);
 
-  return children || null;
+  return null;
 }
 
 export default withRouter(ScrollManager);


### PR DESCRIPTION
In Firefox (and possibly other browsers as well), the ScrollManager would scroll the user to the top of the page after the browser had already honored jumping to an incoming url's specified hash. This meant that you couldn't effectively share links like /#contact-me.

To remedy this, ScrollManager now ignores the initial pathname hydration and only fires its scrollTo behavior for pathname changes after that.