### PR TITLE
Fix feature webp feature detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "reactSnap": {
+    "skipThirdPartyRequests": true
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -58,31 +58,6 @@
 
       gtag('config', 'UA-8759876-2');
     </script>
-    <script>
-      // This implementation is from https://developers.google.com/speed/webp/faq
-      function hasWebPSupport(feature, callback) {
-        var kTestImages = {
-          lossy: 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA',
-          lossless: 'UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==',
-          alpha:
-            'UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAARBxAR/Q9ERP8DAABWUDggGAAAABQBAJ0BKgEAAQAAAP4AAA3AAP7mtQAAAA==',
-          animation:
-            'UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA'
-        };
-        var img = new Image();
-        img.onload = function() {
-          callback(feature, img.width > 0 && img.height > 0);
-        };
-        img.onerror = function() {
-          callback(feature, false);
-        };
-        img.src = 'data:image/webp;base64,' + kTestImages[feature];
-      }
-
-      hasWebPSupport('lossless', (feature, result) => {
-        document.body.classList.add(result ? 'webp' : 'no-webp');
-      });
-    </script>
   </head>
   <body id="top">
     <noscript>You need to enable JavaScript to see this site.</noscript>

--- a/src/featureDetection.js
+++ b/src/featureDetection.js
@@ -1,0 +1,19 @@
+// @flow
+
+type Callback = (feature: string, result: boolean) => any;
+
+export function hasWebPSupport(feature: string, callback: Callback) {
+  const kTestImages = {
+    lossy: 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA',
+    lossless: 'UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==',
+    alpha:
+      'UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAARBxAR/Q9ERP8DAABWUDggGAAAABQBAJ0BKgEAAQAAAP4AAA3AAP7mtQAAAA==',
+    animation:
+      'UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA'
+  };
+  const img = new Image();
+
+  img.onload = () => callback(feature, img.width > 0 && img.height > 0);
+  img.onerror = () => callback(feature, false);
+  img.src = 'data:image/webp;base64,' + kTestImages[feature];
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,14 @@ import AOS from 'aos';
 import 'aos/dist/aos.css';
 
 import App from 'App';
+import { hasWebPSupport } from './featureDetection';
 
 const root = document.getElementById('root');
 
+!navigator.webdriver &&
+  hasWebPSupport('lossless', (feature, result) => {
+    document.body && document.body.classList.add(result ? 'webp' : 'no-webp');
+  });
 smoothscroll.polyfill();
 AOS.init();
 


### PR DESCRIPTION
We were running our feature detection script when we cached our static builds, resulting in all browsers starting with a webp class on the body tag. Browsers that don't support webp would end up with `webp` and `no-webp` classes.

This cleans up our implementation by moving it out of index.html. It also disables feature detection during our static build caching.