### PR TITLE
Disable SPA rewrites

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -30,12 +30,6 @@
   from    = "/projects/"
   to      = "/"
 
-# Server the SPA
-[[redirects]]
-  from    = "/*"
-  to      = "/index.html"
-  status  = 200
-
 # The HTML version is the canonical version of the Resume. Alternate assets
 # can indicate this to crawlers via the link header.
 [[headers]]


### PR DESCRIPTION
We render static versions of all pages at build time, so we don't want to serve up the SPA for all routes as we would for the typical case where we do not have a statically cached version. We instead want to just serve their static equivalents, which happens by default without any special configuration.

Our static rendering also creates a 404.html file. That's the default error handler document, so that should work too without special configuration. Additionally, routes that aren't found will now return hard 404s instead of soft ones. Finally, this also fixes an issue on the 404 page which was causing its content incorrectly to animate out.